### PR TITLE
Fix issue #19, question buttons response in wrong format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 composer.lock
 .php_cs.cache
 /vendor/
+.discovery/

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "botman/studio-addons": "~1.0",
         "illuminate/contracts": "~5.5.0",
         "phpunit/phpunit": "~5.0",
-        "mockery/mockery": "dev-master",
+        "mockery/mockery": "~1.3",
         "ext-curl": "*"
     },
     "autoload": {

--- a/src/BotFrameworkDriver.php
+++ b/src/BotFrameworkDriver.php
@@ -52,7 +52,7 @@ class BotFrameworkDriver extends HttpDriver
     public function getConversationAnswer(IncomingMessage $message)
     {
         if (false !== strpos($message->getText(), '<botman value="')) {
-            preg_match('/<botman value="(.*)"><\/botman>/', $message->getText(), $matches);
+            preg_match('/<botman value="(.*)" \/>/', $message->getText(), $matches);
 
             return Answer::create($message->getText())
                 ->setInteractiveReply(true)

--- a/tests/BotFrameworkDriverTest.php
+++ b/tests/BotFrameworkDriverTest.php
@@ -534,7 +534,7 @@ class BotFrameworkDriverTest extends PHPUnit_Framework_TestCase
             ],
         ]);
 
-        $text = 'I use botman with Skype<botman value="yes"></botman>';
+        $text = 'I use botman with Skype<botman value="yes" />';
         $message = new IncomingMessage($text, '29:2ZC81QtrQQti_yclfvcaNZnRgNSihIXUc6rgigeq82us', '29:2ZC81QtrQQti_yclfvcaNZnRgNSihIXUc6rgigeq82us');
 
         $answer = $driver->getConversationAnswer($message);


### PR DESCRIPTION
Update BotFrameworkDriver.php to correct regex pattern
Update BotFrameworkDriverTest.php it_interactive_responses_correctly to correct hardcoded format expected
Set version number for mockery/mockery as doesn't support phpunit 5